### PR TITLE
Add type checks to typeFnDefault in parser.js

### DIFF
--- a/modules/parser.js
+++ b/modules/parser.js
@@ -2,7 +2,10 @@ import * as registry from './registry'
 import { raf } from './raf'
 
 var typeFnDefault = function (el) {
-  return el.getAttribute('data-widget')
+  if (!el) return null
+  if (!(n instanceof Element)) return null
+
+  return el.getAttribute('data-widget') ?? null
 }
 
 export function parse (el, pattern, typeFn) {

--- a/modules/parser.js
+++ b/modules/parser.js
@@ -3,7 +3,7 @@ import { raf } from './raf'
 
 var typeFnDefault = function (el) {
   if (!el) return null
-  if (!(n instanceof Element)) return null
+  if (!(el instanceof Element)) return null
 
   return el?.getAttribute('data-widget') ?? null
 }

--- a/modules/parser.js
+++ b/modules/parser.js
@@ -5,7 +5,7 @@ var typeFnDefault = function (el) {
   if (!el) return null
   if (!(n instanceof Element)) return null
 
-  return el.getAttribute('data-widget') ?? null
+  return el?.getAttribute('data-widget') ?? null
 }
 
 export function parse (el, pattern, typeFn) {


### PR DESCRIPTION
Add type checks to `typeFnDefault` in `modules/parser.js` to ensure the argument is an element before returning the expected value.

* Add a check to return `null` if the argument is not provided.
* Add a check to return `null` if the argument is not an instance of `Element`.
* Safely call `el.getAttribute('data-widget')` only if the argument is an element.

